### PR TITLE
Add MQTT repeater mode

### DIFF
--- a/cmd/funcs.go
+++ b/cmd/funcs.go
@@ -10,10 +10,11 @@ import (
 )
 
 type functions struct {
-	Login      func() error
-	MQTTListen func(serial string, iot bool) error
-	MQTTHost   func(serial string, iot bool) error
-	GetDevices func() ([]devices.Device, error)
+	Login        func() error
+	MQTTListen   func(serial string, iot bool) error
+	MQTTHost     func(serial string, iot bool) error
+	MQTTRepeater func(serial string, iot bool, ip, user, pw string) error
+	GetDevices   func() ([]devices.Device, error)
 }
 
 var funcs functions
@@ -36,6 +37,9 @@ func init() {
 				_, _ = fmt.Println(in)
 			}),
 		MQTTHost: cli.Host(
+			cloud.GetDevices,
+		),
+		MQTTRepeater: cli.Repeater(
 			cloud.GetDevices,
 		),
 	}

--- a/cmd/repeater.go
+++ b/cmd/repeater.go
@@ -1,0 +1,33 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var repeaterCmd = &cobra.Command{
+	Use:   "repeater serial|ALL",
+	Short: "Repeat device messages to another MQTT broker",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) < 1 {
+			return fmt.Errorf("must specify serial")
+		}
+		iot, _ := cmd.Flags().GetBool("iot")
+		ip, _ := cmd.Flags().GetString("ip")
+		user, _ := cmd.Flags().GetString("user")
+		pw, _ := cmd.Flags().GetString("pw")
+		if ip == "" {
+			return fmt.Errorf("must specify --ip")
+		}
+		return funcs.MQTTRepeater(args[0], iot, ip, user, pw)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(repeaterCmd)
+	repeaterCmd.Flags().BoolP("iot", "", false, "connect through AWS IoT instead of local MQTT")
+	repeaterCmd.Flags().String("ip", "", "address of MQTT broker")
+	repeaterCmd.Flags().String("user", "", "username for MQTT broker")
+	repeaterCmd.Flags().String("pw", "", "password for MQTT broker")
+}


### PR DESCRIPTION
## Summary
- add repeater subcommand to forward messages to another MQTT broker
- implement Repeater helper in internal CLI
- refresh device subscriptions every five minutes in host and repeater modes
- fix device subscription logic when no devices found
- fix case-insensitive check for ALL serial

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_684b8733bab88324ae66103c013bf3eb