### PR TITLE
Add MQTT repeater command

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,12 @@ is included, opendyson will connect to the cloud-based IoT service instead of at
 `opendyson host SERIALNUMBER` starts a local MQTT broker on port 1883. The command subscribes to the same topics as `listen` and republishes
 the messages to the local broker. Use `opendyson host ALL` to bridge all discovered devices. The `--iot` flag can be used in the same way as
 with `listen`.
+
+### Repeat MQTT messages to a remote broker
+
+`opendyson repeater SERIALNUMBER --host HOSTNAME` will subscribe to the same
+topics as `listen` and publish them to the specified MQTT host. Use
+`opendyson repeater ALL` to repeat messages for all discovered devices. Optional
+`--user` and `--password` flags can be supplied for authenticated brokers. If no
+credentials are provided, the connection will be unauthenticated. The `--iot`
+flag can be used in the same way as with `listen`.

--- a/cmd/funcs.go
+++ b/cmd/funcs.go
@@ -10,10 +10,11 @@ import (
 )
 
 type functions struct {
-	Login      func() error
-	MQTTListen func(serial string, iot bool) error
-	MQTTHost   func(serial string, iot bool) error
-	GetDevices func() ([]devices.Device, error)
+	Login        func() error
+	MQTTListen   func(serial string, iot bool) error
+	MQTTHost     func(serial string, iot bool) error
+	MQTTRepeater func(serial string, iot bool, host, user, password string) error
+	GetDevices   func() ([]devices.Device, error)
 }
 
 var funcs functions
@@ -36,6 +37,9 @@ func init() {
 				_, _ = fmt.Println(in)
 			}),
 		MQTTHost: cli.Host(
+			cloud.GetDevices,
+		),
+		MQTTRepeater: cli.Repeater(
 			cloud.GetDevices,
 		),
 	}

--- a/cmd/repeater.go
+++ b/cmd/repeater.go
@@ -1,0 +1,34 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var repeaterCmd = &cobra.Command{
+	Use:   "repeater serial|ALL",
+	Short: "Repeat device MQTT messages to a remote broker",
+	Long:  "Subscribe to device messages and publish them to a remote MQTT broker.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) < 1 {
+			return fmt.Errorf("must specify serial")
+		}
+		iot, _ := cmd.Flags().GetBool("iot")
+		host, _ := cmd.Flags().GetString("host")
+		if host == "" {
+			return fmt.Errorf("host must be specified")
+		}
+		user, _ := cmd.Flags().GetString("user")
+		password, _ := cmd.Flags().GetString("password")
+		return funcs.MQTTRepeater(args[0], iot, host, user, password)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(repeaterCmd)
+	repeaterCmd.Flags().BoolP("iot", "", false, "connect through AWS IoT instead of local MQTT")
+	repeaterCmd.Flags().StringP("host", "", "", "remote MQTT host (hostname or address)")
+	repeaterCmd.Flags().StringP("user", "u", "", "username for remote MQTT host")
+	repeaterCmd.Flags().StringP("password", "p", "", "password for remote MQTT host")
+}

--- a/internal/cli/repeater.go
+++ b/internal/cli/repeater.go
@@ -1,0 +1,125 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	paho "github.com/eclipse/paho.mqtt.golang"
+
+	"github.com/libdyson-wg/opendyson/devices"
+)
+
+func Repeater(
+	getDevices func() ([]devices.Device, error),
+) func(serial string, iot bool, host, user, password string) error {
+	return func(serial string, iot bool, host, user, password string) error {
+		opts := paho.NewClientOptions()
+		if strings.Contains(host, "://") {
+			opts.AddBroker(host)
+		} else {
+			opts.AddBroker(fmt.Sprintf("tcp://%s:1883", host))
+		}
+		opts.SetClientID("opendyson-repeater")
+		if user != "" {
+			opts.SetUsername(user)
+			opts.SetPassword(password)
+		}
+		client := paho.NewClient(opts)
+		t := client.Connect()
+		if !t.WaitTimeout(5 * time.Second) {
+			return fmt.Errorf("mqtt connect %s timeout", host)
+		}
+		if t.Error() != nil {
+			return fmt.Errorf("unable to connect: %w", t.Error())
+		}
+
+		ds, err := getDevices()
+		if err != nil {
+			return err
+		}
+
+		subscribe := func(cd devices.ConnectedDevice) error {
+			if iot {
+				cd.SetMode(devices.ModeIoT)
+			}
+			for _, topic := range []string{cd.StatusTopic(), cd.FaultTopic(), cd.CommandTopic()} {
+				t := topic
+				if err := cd.SubscribeRaw(t, func(b []byte) {
+					fmt.Printf("Incoming message %s on topic %s\n", string(b), t)
+					client.Publish(t, 0, false, b)
+				}); err != nil {
+					return err
+				}
+			}
+
+			if iot {
+				go func() {
+					ticker := time.NewTicker(30 * time.Second)
+					defer ticker.Stop()
+					for {
+						<-ticker.C
+						ts := time.Now().UTC().Format(time.RFC3339)
+						msgs := []string{
+							fmt.Sprintf(`{"mode-reason":"RAPP","time":"%s","msg":"REQUEST-CURRENT-FAULTS"}`, ts),
+							fmt.Sprintf(`{"mode-reason":"RAPP","time":"%s","msg":"REQUEST-CURRENT-STATE"}`, ts),
+						}
+						for _, m := range msgs {
+							fmt.Printf("Sending %s to %s\n", m, cd.CommandTopic())
+							_ = cd.SendRaw(cd.CommandTopic(), []byte(m))
+						}
+					}
+				}()
+			}
+			return nil
+		}
+
+		if strings.EqualFold(serial, "ALL") {
+			found := false
+			for _, d := range ds {
+				cd, ok := d.(devices.ConnectedDevice)
+				if !ok {
+					continue
+				}
+				found = true
+				if err := subscribe(cd); err != nil {
+					return err
+				}
+			}
+			if !found {
+				return fmt.Errorf("no connected devices found")
+			}
+		} else {
+			var d devices.Device
+			for _, dev := range ds {
+				if dev.GetSerial() == serial {
+					d = dev
+					break
+				}
+			}
+			if d == nil {
+				return fmt.Errorf("device with serial %s not found", serial)
+			}
+			cd, ok := d.(devices.ConnectedDevice)
+			if !ok {
+				return fmt.Errorf("device %s is not connected", serial)
+			}
+			if err := subscribe(cd); err != nil {
+				return err
+			}
+		}
+
+		sig := make(chan os.Signal, 1)
+		signal.Notify(sig, syscall.SIGTERM, os.Interrupt)
+		go func() {
+			<-sig
+			client.Disconnect(250)
+			os.Exit(0)
+		}()
+
+		select {}
+	}
+}


### PR DESCRIPTION
## Summary
- add `repeater` command for forwarding device topics to a remote MQTT broker
- wire new repeater functionality into the CLI
- document repeater command in README

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_684b91fbb36c83249c4b8967f4984137